### PR TITLE
Add cornernote's 'craft_guide' mod as optional dependency

### DIFF
--- a/moremesecons_adjustable_blinkyplant/depends.txt
+++ b/moremesecons_adjustable_blinkyplant/depends.txt
@@ -1,1 +1,2 @@
 mesecons
+craft_guide?

--- a/moremesecons_adjustable_player_detector/depends.txt
+++ b/moremesecons_adjustable_player_detector/depends.txt
@@ -1,1 +1,2 @@
 mesecons
+craft_guide?

--- a/moremesecons_commandblock/depends.txt
+++ b/moremesecons_commandblock/depends.txt
@@ -1,2 +1,3 @@
 mesecons
 moremesecons_utils
+craft_guide?

--- a/moremesecons_conductor_signalchanger/depends.txt
+++ b/moremesecons_conductor_signalchanger/depends.txt
@@ -1,1 +1,2 @@
 mesecons
+craft_guide?

--- a/moremesecons_dual_delayer/depends.txt
+++ b/moremesecons_dual_delayer/depends.txt
@@ -1,1 +1,2 @@
 mesecons
+craft_guide?

--- a/moremesecons_entity_detector/depends.txt
+++ b/moremesecons_entity_detector/depends.txt
@@ -1,1 +1,2 @@
 mesecons
+craft_guide?

--- a/moremesecons_igniter/depends.txt
+++ b/moremesecons_igniter/depends.txt
@@ -1,2 +1,3 @@
 mesecons
 fire
+craft_guide?

--- a/moremesecons_injector_controller/depends.txt
+++ b/moremesecons_injector_controller/depends.txt
@@ -1,1 +1,2 @@
 mesecons
+craft_guide?

--- a/moremesecons_jammer/depends.txt
+++ b/moremesecons_jammer/depends.txt
@@ -1,2 +1,3 @@
 mesecons
 moremesecons_utils
+craft_guide?

--- a/moremesecons_playerkiller/depends.txt
+++ b/moremesecons_playerkiller/depends.txt
@@ -1,3 +1,4 @@
 mesecons
 mesecons_materials
 moremesecons_utils
+craft_guide?

--- a/moremesecons_sayer/depends.txt
+++ b/moremesecons_sayer/depends.txt
@@ -2,3 +2,4 @@ mesecons
 mesecons_noteblock
 moremesecons_utils
 default
+craft_guide?

--- a/moremesecons_signalchanger/depends.txt
+++ b/moremesecons_signalchanger/depends.txt
@@ -1,1 +1,2 @@
 mesecons
+craft_guide?

--- a/moremesecons_switchtorch/depends.txt
+++ b/moremesecons_switchtorch/depends.txt
@@ -1,1 +1,2 @@
 mesecons
+craft_guide?

--- a/moremesecons_teleporter/depends.txt
+++ b/moremesecons_teleporter/depends.txt
@@ -1,2 +1,3 @@
 mesecons
 moremesecons_utils
+craft_guide?

--- a/moremesecons_timegate/depends.txt
+++ b/moremesecons_timegate/depends.txt
@@ -1,1 +1,2 @@
 mesecons
+craft_guide?

--- a/moremesecons_wireless/depends.txt
+++ b/moremesecons_wireless/depends.txt
@@ -1,3 +1,4 @@
 mesecons
 moremesecons_utils
 digilines?
+craft_guide?


### PR DESCRIPTION
Ensures that craft recipes are registered in [cornernote's *craft_guide* mod](http://cornernote.github.io/minetest-craft_guide/).

Added to the following mods with craft recipes:
- adjustable_blinkyplant
- adjustable_player_detector
- commandblock
- conductor_signalchanger
- dual_delayer
- entity_detector
- igniter
- injector_controller
- jammer
- playerkiller
- sayer
- signalchanger
- switchtorch
- teleporter
- timegate
- wireless