### PR TITLE
Use opaque use_texture_alpha for the timegate and dual_delayer

### DIFF
--- a/moremesecons_dual_delayer/init.lua
+++ b/moremesecons_dual_delayer/init.lua
@@ -58,6 +58,10 @@ for n,i in pairs({{0,0},{1,0},{1,1}}) do
 		top_texture = pre..top_texture
 	end
 
+	local use_texture_alpha
+	if minetest.features.use_texture_alpha_string_modes then
+		use_texture_alpha = "opaque"
+	end
 	minetest.register_node("moremesecons_dual_delayer:dual_delayer_"..i1 ..i2, {
 		description = "Dual Delayer",
 		drop = "moremesecons_dual_delayer:dual_delayer_00",
@@ -74,7 +78,7 @@ for n,i in pairs({{0,0},{1,0},{1,1}}) do
 		},
 		groups = groups,
 		tiles = {top_texture, "moremesecons_dual_delayer_bottom.png", "moremesecons_dual_delayer_side_left.png", "moremesecons_dual_delayer_side_right.png", "moremesecons_dual_delayer_ends.png", "moremesecons_dual_delayer_ends.png"},
-		use_texture_alpha = "opaque",
+		use_texture_alpha = use_texture_alpha,
 		mesecons = {
 			receptor = {
 				state = mesecon.state.off,

--- a/moremesecons_dual_delayer/init.lua
+++ b/moremesecons_dual_delayer/init.lua
@@ -74,6 +74,7 @@ for n,i in pairs({{0,0},{1,0},{1,1}}) do
 		},
 		groups = groups,
 		tiles = {top_texture, "moremesecons_dual_delayer_bottom.png", "moremesecons_dual_delayer_side_left.png", "moremesecons_dual_delayer_side_right.png", "moremesecons_dual_delayer_ends.png", "moremesecons_dual_delayer_ends.png"},
+		use_texture_alpha = "opaque",
 		mesecons = {
 			receptor = {
 				state = mesecon.state.off,

--- a/moremesecons_timegate/init.lua
+++ b/moremesecons_timegate/init.lua
@@ -84,6 +84,7 @@ mesecon.register_node("moremesecons_timegate:timegate", {
 			"moremesecons_timegate_sides_off.png",
 			"moremesecons_timegate_sides_off.png"
 		},
+		use_texture_alpha = "opaque",
 		groups = {bendy=2,snappy=1,dig_immediate=2},
 		mesecons = {
 			receptor =
@@ -106,6 +107,7 @@ mesecon.register_node("moremesecons_timegate:timegate", {
 			"moremesecons_timegate_sides_on.png",
 			"moremesecons_timegate_sides_on.png"
 		},
+		use_texture_alpha = "opaque",
 		groups = {bendy=2,snappy=1,dig_immediate=2, not_in_creative_inventory=1},
 		mesecons = {
 			receptor = {

--- a/moremesecons_timegate/init.lua
+++ b/moremesecons_timegate/init.lua
@@ -47,6 +47,10 @@ local boxes = {{ -6/16, -8/16, -6/16, 6/16, -7/16, 6/16 },		-- the main slab
 	 { -8/16, -8/16, -1/16, -6/16, -7/16, 1/16 },		-- the two wire stubs
 	 { 6/16, -8/16, -1/16, 8/16, -7/16, 1/16 }}
 
+local use_texture_alpha
+if minetest.features.use_texture_alpha_string_modes then
+	use_texture_alpha = "opaque"
+end
 mesecon.register_node("moremesecons_timegate:timegate", {
 	description = "Time Gate",
 	drawtype = "nodebox",
@@ -84,7 +88,7 @@ mesecon.register_node("moremesecons_timegate:timegate", {
 			"moremesecons_timegate_sides_off.png",
 			"moremesecons_timegate_sides_off.png"
 		},
-		use_texture_alpha = "opaque",
+		use_texture_alpha = use_texture_alpha,
 		groups = {bendy=2,snappy=1,dig_immediate=2},
 		mesecons = {
 			receptor =
@@ -107,7 +111,7 @@ mesecon.register_node("moremesecons_timegate:timegate", {
 			"moremesecons_timegate_sides_on.png",
 			"moremesecons_timegate_sides_on.png"
 		},
-		use_texture_alpha = "opaque",
+		use_texture_alpha = use_texture_alpha,
 		groups = {bendy=2,snappy=1,dig_immediate=2, not_in_creative_inventory=1},
 		mesecons = {
 			receptor = {


### PR DESCRIPTION
This avoids warnings shown by Minetest and can improve the nodes' look when a bilinear filter is enabled.
Since the textures are also used as inventory images, I didn't remove the transparency from the texture files.