### PR TITLE
commandblock: don't allow sending colored text if server forbids it

### DIFF
--- a/moremesecons_commandblock/init.lua
+++ b/moremesecons_commandblock/init.lua
@@ -1,3 +1,5 @@
+local strip_color_codes = minetest.settings:get_bool("strip_color_codes", false)
+
 local function initialize_data(meta)
 	local NEAREST_MAX_DISTANCE = moremesecons.setting("commandblock", "nearest_max_distance", 8, 1)
 
@@ -46,7 +48,11 @@ local function receive_fields(pos, _, fields, player)
 	and player:get_player_name() ~= owner then
 		return
 	end
-	meta:set_string("commands", fields.commands)
+	if strip_color_codes then
+		meta:set_string("commands", minetest.strip_colors(fields.commands))
+	else
+		meta:set_string("commands", fields.commands)
+	end
 
 	initialize_data(meta)
 end


### PR DESCRIPTION
currently, players can get around the [strip_color_codes](https://github.com/minetest/minetest/blob/587f6656a4b86346e35da1b43b48b832d3f1b32e/builtin/settingtypes.txt#L690-L692) setting by putting color escape sequences in a command block. this PR prevents that. 