### PR TITLE
create limit on length of command block scripts to prevent server crashes

### DIFF
--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -13,6 +13,10 @@ moremesecons_commandblock.authorized_commands (Authorized commands) string tell
 # Any value less than or equal to 0 will be changed to 1 and a NaN value will be changed to the default value
 moremesecons_commandblock.nearest_max_distance (Nearest player maximum distance) float 8
 
+# Set to 0 to disable. It is highly recommended to not allow scripts longer than 65000 characters, as long
+# messages can crash a server.
+moremesecons_commandblock.max_script_length (Maximum Script Length) int 65000 0
+
 [Signal Jammer]
 
 # Jammer action range


### PR DESCRIPTION
currently, the moremesecons command block can be used to crash a server by trying to send a message that is larger than the engine can handle (see https://github.com/minetest/minetest/issues/9326). this PR avoids that by setting a maximum script length for the command block. 

to test:
```
tell @nearest (some string that's 65536 characters, apparently that's too long for github)
```