### PR TITLE
Fix crash with command blocks

### DIFF
--- a/moremesecons_commandblock/init.lua
+++ b/moremesecons_commandblock/init.lua
@@ -56,7 +56,7 @@ local function resolve_commands(commands, pos)
 	local min_distance = math.huge
 	local players = minetest.get_connected_players()
 	for _, player in pairs(players) do
-		local distance = vector.distance(pos, player:getpos())
+		local distance = vector.distance(pos, player:get_pos())
 		if distance < min_distance then
 			min_distance = distance
 			nearest = player:get_player_name()

--- a/moremesecons_commandblock/init.lua
+++ b/moremesecons_commandblock/init.lua
@@ -52,7 +52,7 @@ local function receive_fields(pos, _, fields, player)
 end
 
 local function resolve_commands(commands, pos)
-	local nearest = nil
+	local nearest = ""
 	local min_distance = math.huge
 	local players = minetest.get_connected_players()
 	for _, player in pairs(players) do


### PR DESCRIPTION
If no-one is online and a command block that contains @​nearest is (somehow) activated the server will crash, I believe this can happen with forceloaded blocks.

Maybe it'd be better to abort the command execution instead, mesecons has a [fix that does this](https://github.com/minetest-mods/mesecons/commit/f9f7600017967672ec28ecf139d9d520d64fcef0).