### PR TITLE
Add missing dependencies

### DIFF
--- a/moremesecons_adjustable_blinkyplant/mod.conf
+++ b/moremesecons_adjustable_blinkyplant/mod.conf
@@ -1,3 +1,3 @@
 name = moremesecons_adjustable_blinkyplant
-depends = mesecons,moremesecons_utils
+depends = mesecons,moremesecons_utils,default
 optional_depends = craft_guide

--- a/moremesecons_adjustable_player_detector/mod.conf
+++ b/moremesecons_adjustable_player_detector/mod.conf
@@ -1,3 +1,3 @@
 name = moremesecons_adjustable_player_detector
-depends = mesecons
+depends = mesecons,moremesecons_utils
 optional_depends = craft_guide

--- a/moremesecons_adjustable_player_detector/mod.conf
+++ b/moremesecons_adjustable_player_detector/mod.conf
@@ -1,3 +1,3 @@
 name = moremesecons_adjustable_player_detector
-depends = mesecons,moremesecons_utils
+depends = mesecons,moremesecons_utils,default
 optional_depends = craft_guide

--- a/moremesecons_commandblock/mod.conf
+++ b/moremesecons_commandblock/mod.conf
@@ -1,3 +1,3 @@
 name = moremesecons_commandblock
-depends = mesecons,moremesecons_utils
+depends = mesecons,moremesecons_utils,default
 optional_depends = craft_guide

--- a/moremesecons_entity_detector/mod.conf
+++ b/moremesecons_entity_detector/mod.conf
@@ -1,3 +1,3 @@
 name = moremesecons_entity_detector
-depends = mesecons,moremesecons_utils
+depends = mesecons,moremesecons_utils,default
 optional_depends = craft_guide

--- a/moremesecons_entity_detector/mod.conf
+++ b/moremesecons_entity_detector/mod.conf
@@ -1,3 +1,3 @@
 name = moremesecons_entity_detector
-depends = mesecons
+depends = mesecons,moremesecons_utils
 optional_depends = craft_guide

--- a/moremesecons_playerkiller/mod.conf
+++ b/moremesecons_playerkiller/mod.conf
@@ -1,3 +1,3 @@
 name = moremesecons_playerkiller
-depends = mesecons,mesecons_materials,moremesecons_utils
+depends = mesecons,mesecons_materials,moremesecons_utils,default
 optional_depends = craft_guide

--- a/moremesecons_teleporter/mod.conf
+++ b/moremesecons_teleporter/mod.conf
@@ -1,3 +1,3 @@
 name = moremesecons_teleporter
-depends = mesecons,moremesecons_utils
+depends = mesecons,moremesecons_utils,default
 optional_depends = craft_guide

--- a/moremesecons_timegate/mod.conf
+++ b/moremesecons_timegate/mod.conf
@@ -1,3 +1,3 @@
 name = moremesecons_timegate
-depends = mesecons
+depends = mesecons,default
 optional_depends = craft_guide

--- a/moremesecons_wireless/mod.conf
+++ b/moremesecons_wireless/mod.conf
@@ -1,3 +1,3 @@
 name = moremesecons_wireless
-depends = mesecons,moremesecons_utils
+depends = mesecons,moremesecons_utils,default
 optional_depends = digilines,craft_guide


### PR DESCRIPTION
fixes ##40

There are still some mods in this modpack that don't depend on `moremesecons_utils` because they don't use anything of the form `moremesecons.*`. But IMO it would be good to still have this dependencies to avoid possible crashes in the future... Should I add these?

I looked for other unsatisfied dependencies and found a default (commit 2).