### PR TITLE
[no squash] Various fixes

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,6 +1,6 @@
 read_globals = {
 	-- Defined by Minetest
-	"minetest", "vector", "PseudoRandom", "VoxelArea", "table",
+	"minetest", "vector", "PseudoRandom", "VoxelArea", "table", "ItemStack",
 
 	-- Mods
 	"digiline", "default", "creative",

--- a/moremesecons_conductor_signalchanger/init.lua
+++ b/moremesecons_conductor_signalchanger/init.lua
@@ -45,10 +45,11 @@ mesecon.register_node("moremesecons_conductor_signalchanger:conductor_signalchan
 	inventory_image = "moremesecons_conductor_signalchanger_off.png",
 	groups = {dig_immediate = 2},
 	paramtype = "light",
-	paramtype2 = "facedir",
+	paramtype2 = "4dir",
 	drawtype = "nodebox",
 	selection_box = nodebox,
 	node_box = nodebox,
+	on_rotate = mesecon.on_rotate,
 },{
 	groups = {dig_immediate = 2},
 	mesecons = {

--- a/moremesecons_dual_delayer/init.lua
+++ b/moremesecons_dual_delayer/init.lua
@@ -68,7 +68,7 @@ for n,i in pairs({{0,0},{1,0},{1,1}}) do
 		inventory_image = top_texture,
 		wield_image = top_texture,
 		paramtype = "light",
-		paramtype2 = "facedir",
+		paramtype2 = "4dir",
 		drawtype = "nodebox",
 		node_box = {
 			type = "fixed",
@@ -79,6 +79,7 @@ for n,i in pairs({{0,0},{1,0},{1,1}}) do
 		groups = groups,
 		tiles = {top_texture, "moremesecons_dual_delayer_bottom.png", "moremesecons_dual_delayer_side_left.png", "moremesecons_dual_delayer_side_right.png", "moremesecons_dual_delayer_ends.png", "moremesecons_dual_delayer_ends.png"},
 		use_texture_alpha = use_texture_alpha,
+		on_rotate = mesecon.on_rotate,
 		mesecons = {
 			receptor = {
 				state = mesecon.state.off,

--- a/moremesecons_entity_detector/init.lua
+++ b/moremesecons_entity_detector/init.lua
@@ -46,9 +46,14 @@ local object_detector_scan = function (pos)
 				return true
 			end
 			local isname = luaentity.name
+			-- If the item is present as dropped item entity:
+			local bitemname = (isname == "__builtin:item" and ItemStack(luaentity.itemstring):get_name())
 			for _, name in ipairs(scan_names) do
-				if isname == name or (isname == "__builtin:item" and luaentity.itemstring == name) then
-					return true
+				if name == isname then
+					return true -- object name matches
+				end
+				if name == bitemname then
+					return true -- item of the item entity matches
 				end
 			end
 		end

--- a/moremesecons_induction_transmitter/init.lua
+++ b/moremesecons_induction_transmitter/init.lua
@@ -58,6 +58,7 @@ mesecon.register_node("moremesecons_induction_transmitter:induction_transmitter"
 			{-0.25, -0.25, -0.5, 0.25, 0.25, -0.1875},
 		},
 	},
+	on_rotate = mesecon.on_rotate,
 }, {
 	tiles = {"default_mese_block.png"},
 	groups = {cracky = 3},

--- a/moremesecons_injector_controller/init.lua
+++ b/moremesecons_injector_controller/init.lua
@@ -42,12 +42,13 @@ mesecon.register_node("moremesecons_injector_controller:injector_controller", {
 	drawtype = "nodebox",
 	inventory_image = "moremesecons_injector_controller_off.png",
 	paramtype = "light",
-	paramtype2 = "facedir",
+	paramtype2 = "4dir",
 	node_box = {
 		type = "fixed",
 		fixed = {{-8/16, -8/16, -8/16, 8/16, -7/16, 8/16 }},
 	},
 	on_timer = on_timer,
+	on_rotate = mesecon.on_rotate,
 },{
 	tiles = {"moremesecons_injector_controller_off.png", "moremesecons_injector_controller_side.png", "moremesecons_injector_controller_side.png"},
 	groups = {dig_immediate=2},

--- a/moremesecons_signalchanger/init.lua
+++ b/moremesecons_signalchanger/init.lua
@@ -41,10 +41,11 @@ mesecon.register_node("moremesecons_signalchanger:signalchanger", {
 	inventory_image = "moremesecons_signalchanger_off.png",
 	groups = {dig_immediate = 2},
 	paramtype = "light",
-	paramtype2 = "facedir",
+	paramtype2 = "4dir",
 	drawtype = "nodebox",
 	selection_box = nodebox,
 	node_box = nodebox,
+	on_rotate = mesecon.on_rotate,
 },{
 	groups = {dig_immediate = 2},
 	mesecons = {

--- a/moremesecons_timegate/init.lua
+++ b/moremesecons_timegate/init.lua
@@ -71,7 +71,7 @@ mesecon.register_node("moremesecons_timegate:timegate", {
 		fixed = boxes
 	},
 	paramtype = "light",
-	paramtype2 = "facedir",
+	paramtype2 = "4dir",
 	sunlight_propagates = true,
 	is_ground_content = true,
 	sounds = default.node_sound_stone_defaults(),
@@ -84,7 +84,8 @@ mesecon.register_node("moremesecons_timegate:timegate", {
 			minetest.get_meta(pos):set_string("time", fields.time)
 		end
 	end,
-	on_timer = turnoff
+	on_timer = turnoff,
+	on_rotate = mesecon.on_rotate
 },{
 		tiles = {
 			"moremesecons_timegate_off.png",

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -69,6 +69,11 @@ moremesecons_teleporter.max_p2t_distance (Maximum Player To Teleporter distance)
 # from an older version which did not use it.
 moremesecons_teleporter.enable_lbm (Enable Registration LBM) bool false
 
+[Timegate]
+
+# Minimum authorized length for the timegate signal. Timegates with a shorter time will not respond.
+moremesecons_timegate.min_delay (Minimum timegate delay) float 0.5
+
 [Wireless]
 
 # Whether to enable the wireless jammer node


### PR DESCRIPTION
3 fixes that are independent of each other. If preferred, I can open a pr for each one.

crash mentioned in commit 1: set a timegate to `nan` and power it
```
2025-11-11 15:41:08: ERROR[Main]: ServerError: AsyncErr: Lua: Runtime error from mod 'mesecons' in callback environment_Step(): .../yl/5.13.0/Yourland_test/bin/../builtin/common/after.lua:173: Invalid core.after invocation
2025-11-11 15:41:08: ERROR[Main]: stack traceback:
2025-11-11 15:41:08: ERROR[Main]: 	[C]: in function 'assert'
2025-11-11 15:41:08: ERROR[Main]: 	.../yl/5.13.0/Yourland_test/bin/../builtin/common/after.lua:173: in function 'after'
2025-11-11 15:41:08: ERROR[Main]: 	...nd_test/mods/MoreMesecons/moremesecons_timegate/init.lua:28: in function 'action_on'
2025-11-11 15:41:08: ERROR[Main]: 	...5.13.0/Yourland_test/mods/mesecons/mesecons/internal.lua:184: in function <...5.13.0/Yourland_test/mods/mesecons/mesecons/internal.lua:177>
2025-11-11 15:41:08: ERROR[Main]: 	...3.0/Yourland_test/mods/mesecons/mesecons/actionqueue.lua:131: in function 'old_execute'
2025-11-11 15:41:08: ERROR[Main]: 	...nd_test/mods/mesecons_debug/overrides/mesecons_queue.lua:27: in function 'execute'
2025-11-11 15:41:08: ERROR[Main]: 	...3.0/Yourland_test/mods/mesecons/mesecons/actionqueue.lua:121: in function 'func'
2025-11-11 15:41:08: ERROR[Main]: 	...ourland_test/bin/../builtin/profiler/instrumentation.lua:111: in function <...ourland_test/bin/../builtin/profiler/instrumentation.lua:104>
2025-11-11 15:41:08: ERROR[Main]: 	.../5.13.0/Yourland_test/bin/../builtin/common/register.lua:26: in function <.../5.13.0/Yourland_test/bin/../builtin/common/register.lua:12>
```

commit 2:
`luaent.itemstring` of `__builtin:item` contains the stacksize too. 

commit 3:
If these nodes work only when flat on the ground, they shouldn't allow other rotations...